### PR TITLE
Add initial compute related metal-d bindings

### DIFF
--- a/source/metal/computepipeline.d
+++ b/source/metal/computepipeline.d
@@ -1,0 +1,125 @@
+/**
+    MTLRenderPipeline
+
+    Copyright: Copyright © 2024-2025, Kitsunebi Games EMV
+    License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+    Authors:   Asadbek Sindarov 
+*/
+
+
+module metal.computepipeline;
+import metal.library;
+import metal.renderpass;
+import metal.types;
+import metal.device;
+import metal.argument;
+import foundation;
+import metal.buffer;
+import metal.commandencoder;
+import objc;
+import core.attribute : selector, optional;
+
+extern (Objective-C)
+extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
+  /**
+    Configures the compute encoder with a pipeline state for subsequent kernel calls.
+  */
+  void setComputePipelineState(MTLComputePipelineState state) @selector("setComputePipelineState:");
+
+  /**
+    Binds a buffer to the buffer argument table, allowing compute kernels to access its data on the GPU.
+  */ 
+    void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index) @selector("setBuffer:offset:atIndex:");
+
+
+  /**
+    Encodes a compute command using an arbitrarily sized grid.
+  */
+  void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreads:threadsPerThreadgroup:");
+
+  /**
+    Encodes a compute dispatch command using a grid aligned to threadgroup boundaries.
+  */
+  void dispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreadgroups:threadsPerThreadgroup:");
+
+  /**
+    Declares that all command generation from the encoder is completed.
+  */
+  void endEncoding() @selector("endEncoding");
+}
+
+
+/**
+  Information about the arguments of a compute function.
+*/
+extern (Objective-C)
+extern interface MTLComputePipelineReflection : NSObjectProtocol {
+@nogc nothrow
+public:
+  @property NSArray!MTLBinding bindings() @selector("bindings");
+}
+
+/**
+  A convenience type alias for an autoreleased compute pipeline reflection object.
+*/
+alias MTLAutoreleasedComputePipelineReflection = MTLComputePipelineReflection;
+
+/**
+  An interface that represents a GPU pipeline configuration for running kernels in a compute pass.
+*/
+extern (Objective-C)
+extern interface MTLComputePipelineState : NSObjectProtocol {
+@nogc nothrow
+public:
+    /**
+        The GPU device that created the command queue.
+    */
+    @property MTLDevice device() const;
+
+    /**
+        An optional name that can help you identify the command queue.
+    */
+    @property NSString label();
+    @property void label(NSString);
+
+    /**
+        An unique identifier that represents the pipeline state, 
+        which you can add to an argument buffer.
+    */
+    @property MTLResourceID gpuResourceID() const;
+
+    /**
+        The largest number of threads the pipeline state can have 
+        in a single object shader threadgroup.
+    */
+    @property NSUInteger maxTotalThreadsPerThreadgroup() const;
+
+    /**
+        The number of threads the render pass applies to a SIMD group 
+        for an object shader.
+    */
+    @property NSUInteger threadExecutionWidth() const;
+
+    /**
+      The length, in bytes, of statically allocated threadgroup memory.
+    */
+    @property NSUInteger staticThreadgroupMemoryLength() const;
+
+      /**
+        Returns the length of an imageblock’s memory for the specified
+        imageblock dimensions.
+    */
+    @property NSUInteger imageblockMemoryLengthForDimensions(MTLSize imageblockDimensions) @selector(
+        "imageblockMemoryLengthForDimensions:") ;
+
+    /**
+      A Boolean value that indicates whether the compute pipeline supports indirect command buffers.
+    */
+   @property bool supportIndirectCommandBuffers() const; 
+
+   /**
+        The current state of shader validation for the pipeline.
+    */
+    @property MTLShaderValidation shaderValidation() const;
+}
+

--- a/source/metal/computepipeline.d
+++ b/source/metal/computepipeline.d
@@ -19,51 +19,70 @@ import core.attribute : selector, optional;
 
 extern (Objective-C)
 extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
-  
-  /**
-    Configures the compute encoder with a pipeline state for subsequent kernel calls.
-  */
-  void setComputePipelineState(MTLComputePipelineState state) @selector("setComputePipelineState:");
 
-  /**
-    Binds a buffer to the buffer argument table, allowing compute kernels to access its data on the GPU.
-  */ 
+    /** 
+        Configures the compute encoder with a pipeline state for subsequent kernel calls. 
+    
+        Params:
+          state = An $(D MTLComputePipelineState) instance
+    */
+    void setComputePipelineState(MTLComputePipelineState state) @selector("setComputePipelineState:");
+
+    /**
+        Binds a buffer to the buffer argument table, allowing compute kernels to access its data on the GPU.
+
+        Params:
+          buffer = The $(D MTLBuffer) instance to bind to the argument table.
+          offset = The number of bytes to skip in the buffer before the first element of data.
+          index = The index the buffer binds to in the argument table.
+    */
     void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index) @selector("setBuffer:offset:atIndex:");
 
-  /**
-    Encodes a compute command using an arbitrarily sized grid.
-  */
-  void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreads:threadsPerThreadgroup:");
+    /**
+        Encodes a compute command using an arbitrarily sized grid.
 
-  /**
-    Encodes a compute dispatch command using a grid aligned to threadgroup boundaries.
-  */
-  void dispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreadgroups:threadsPerThreadgroup:");
+        Params:
+          threadsPerGrid = The number of threads in the grid, in each dimension.
+          threadsPerThreadgroup = The number of threads in one threadgroup, in each dimension.
+    */
+    void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreads:threadsPerThreadgroup:");
 
-  /**
-    Declares that all command generation from the encoder is completed.
-  */
-  void endEncoding() @selector("endEncoding");
+    /**
+        Encodes a compute dispatch command using a grid aligned to threadgroup boundaries.
+    
+        Params:
+          threadgroupsPerGrid = An $(D MTLSize) instance that represents the number of threads for each grid dimension.
+          threadsPerThreadgroup = An $(D MTLSize) instance that represents the number of threads in a threadgroup.
+    */
+    void dispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreadgroups:threadsPerThreadgroup:");
+
+    /**
+        Declares that all command generation from the encoder is completed.
+    */
+    void endEncoding() @selector("endEncoding");
 }
 
 /**
-  Information about the arguments of a compute function.
+    Information about the arguments of a compute function.
 */
 extern (Objective-C)
 extern interface MTLComputePipelineReflection : NSObjectProtocol {
 @nogc nothrow
 public:
 
-  @property NSArray!MTLBinding bindings() @selector("bindings");
+    /** 
+        An array of $(D MTLBinding) objects that describe the arguments of the compute function.
+    */
+    @property NSArray!MTLBinding bindings() @selector("bindings");
 }
 
 /**
-  A convenience type alias for an autoreleased compute pipeline reflection object.
+    A convenience type alias for an autoreleased compute pipeline reflection object.
 */
 alias MTLAutoreleasedComputePipelineReflection = MTLComputePipelineReflection;
 
 /**
-  An interface that represents a GPU pipeline configuration for running kernels in a compute pass.
+    An interface that represents a GPU pipeline configuration for running kernels in a compute pass.
 */
 extern (Objective-C)
 extern interface MTLComputePipelineState : NSObjectProtocol {
@@ -71,12 +90,12 @@ extern interface MTLComputePipelineState : NSObjectProtocol {
 public:
 
     /**
-        The GPU device that created the command queue.
+        The device instance that created the pipeline state.
     */
     @property MTLDevice device() const;
 
     /**
-        An optional name that can help you identify the command queue.
+        A string that helps identify the compute pipeline state during debugging.
     */
     @property NSString label();
     @property void label(NSString);
@@ -88,35 +107,32 @@ public:
     @property MTLResourceID gpuResourceID() const;
 
     /**
-        The largest number of threads the pipeline state can have 
-        in a single object shader threadgroup.
+        The maximum number of threads in a threadgroup that can be dispatch to the pipeline.
     */
     @property NSUInteger maxTotalThreadsPerThreadgroup() const;
 
     /**
-        The number of threads the render pass applies to a SIMD group 
-        for an object shader.
+        The number of threads that the GPU executes simultaneously.
     */
     @property NSUInteger threadExecutionWidth() const;
 
     /**
-      The length, in bytes, of statically allocated threadgroup memory.
+        The length, in bytes, of statically allocated threadgroup memory.
     */
     @property NSUInteger staticThreadgroupMemoryLength() const;
 
-      /**
-        Returns the length of an imageblock’s memory for the specified
-        imageblock dimensions.
+    /**
+        Returns the length of reserved memory for an imageblock of a given size.
     */
     @property NSUInteger imageblockMemoryLengthForDimensions(MTLSize imageblockDimensions) @selector(
         "imageblockMemoryLengthForDimensions:") ;
 
     /**
-      A Boolean value that indicates whether the compute pipeline supports indirect command buffers.
+        A Boolean value that indicates whether the compute pipeline supports indirect command buffers.
     */
    @property bool supportIndirectCommandBuffers() const; 
 
-   /**
+    /**
         The current state of shader validation for the pipeline.
     */
     @property MTLShaderValidation shaderValidation() const;

--- a/source/metal/computepipeline.d
+++ b/source/metal/computepipeline.d
@@ -5,8 +5,6 @@
     License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
     Authors:   Asadbek Sindarov 
 */
-
-
 module metal.computepipeline;
 import metal.library;
 import metal.renderpass;
@@ -21,6 +19,7 @@ import core.attribute : selector, optional;
 
 extern (Objective-C)
 extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
+  
   /**
     Configures the compute encoder with a pipeline state for subsequent kernel calls.
   */
@@ -30,7 +29,6 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
     Binds a buffer to the buffer argument table, allowing compute kernels to access its data on the GPU.
   */ 
     void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index) @selector("setBuffer:offset:atIndex:");
-
 
   /**
     Encodes a compute command using an arbitrarily sized grid.
@@ -48,7 +46,6 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
   void endEncoding() @selector("endEncoding");
 }
 
-
 /**
   Information about the arguments of a compute function.
 */
@@ -56,6 +53,7 @@ extern (Objective-C)
 extern interface MTLComputePipelineReflection : NSObjectProtocol {
 @nogc nothrow
 public:
+
   @property NSArray!MTLBinding bindings() @selector("bindings");
 }
 
@@ -71,6 +69,7 @@ extern (Objective-C)
 extern interface MTLComputePipelineState : NSObjectProtocol {
 @nogc nothrow
 public:
+
     /**
         The GPU device that created the command queue.
     */
@@ -122,4 +121,3 @@ public:
     */
     @property MTLShaderValidation shaderValidation() const;
 }
-

--- a/source/metal/computepipeline.d
+++ b/source/metal/computepipeline.d
@@ -24,7 +24,7 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
         Configures the compute encoder with a pipeline state for subsequent kernel calls. 
     
         Params:
-          state = An $(D MTLComputePipelineState) instance
+            state = An $(D MTLComputePipelineState) instance
     */
     void setComputePipelineState(MTLComputePipelineState state) @selector("setComputePipelineState:");
 
@@ -32,9 +32,9 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
         Binds a buffer to the buffer argument table, allowing compute kernels to access its data on the GPU.
 
         Params:
-          buffer = The $(D MTLBuffer) instance to bind to the argument table.
-          offset = The number of bytes to skip in the buffer before the first element of data.
-          index = The index the buffer binds to in the argument table.
+            buffer = The $(D MTLBuffer) instance to bind to the argument table.
+            offset = The number of bytes to skip in the buffer before the first element of data.
+            index = The index the buffer binds to in the argument table.
     */
     void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index) @selector("setBuffer:offset:atIndex:");
 
@@ -42,8 +42,8 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
         Encodes a compute command using an arbitrarily sized grid.
 
         Params:
-          threadsPerGrid = The number of threads in the grid, in each dimension.
-          threadsPerThreadgroup = The number of threads in one threadgroup, in each dimension.
+            threadsPerGrid = The number of threads in the grid, in each dimension.
+            threadsPerThreadgroup = The number of threads in one threadgroup, in each dimension.
     */
     void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreads:threadsPerThreadgroup:");
 
@@ -51,8 +51,8 @@ extern interface MTLComputeCommandEncoder : MTLCommandEncoder {
         Encodes a compute dispatch command using a grid aligned to threadgroup boundaries.
     
         Params:
-          threadgroupsPerGrid = An $(D MTLSize) instance that represents the number of threads for each grid dimension.
-          threadsPerThreadgroup = An $(D MTLSize) instance that represents the number of threads in a threadgroup.
+            threadgroupsPerGrid = An $(D MTLSize) instance that represents the number of threads for each grid dimension.
+            threadsPerThreadgroup = An $(D MTLSize) instance that represents the number of threads in a threadgroup.
     */
     void dispatchThreadgroups(MTLSize threadgroupsPerGrid, MTLSize threadsPerThreadgroup) @selector("dispatchThreadgroups:threadsPerThreadgroup:");
 

--- a/source/metal/device.d
+++ b/source/metal/device.d
@@ -720,12 +720,30 @@ public:
     MTLLibrary newLibrary(NSString source, MTLCompileOptions options, ref NSError error) @selector("newLibraryWithSource:options:error:");
 
     /**
-      Creates a Metal library instance that contains the functions in the Metal library file at a URL.
-      */
+        Creates a Metal library instance that contains the functions in the Metal library file at a URL.
+
+        Params:
+            url =   A URL to a Metal library file (ending in .metallib).
+            error = On return, if an error occurs, a pointer to an error information instance; otherwise, $(D null).
+
+        Returns:
+            A $(D MTLLibrary) loaded from the file at $(D url) on success,
+            $(D null) otherwise.
+    */
     MTLLibrary newLibrary(NSURL url, ref NSError error) @selector("newLibraryWithURL:error:");
 
     /** 
-      Synchronously creates a compute pipeline state and reflection with a function instance.
+        Synchronously creates a compute pipeline state and reflection with a function instance.
+
+        Params:
+            computeFunction = An $(D MTLFunction) instance.
+            options = An $(D MTLPipelineOption) instance that represents the reflection information you want the method to generate.
+            reflection = an $(D MTLAutoreleasedComputePipelineReflection) instance.
+            error = On return, if an error occurs, a pointer to an error information instance; otherwise, $(D null).
+
+        Returns:
+            A $(D MTLComputePipelineState) instance on success,
+            $(D null) otherwise.
      */
     MTLComputePipelineState newComputePipelineStateWithFunction(MTLFunction computeFunction, MTLPipelineOption options, MTLAutoreleasedComputePipelineReflection reflection, NSError error) @selector("newComputePipelineStateWithFunction:options:reflection:error:"); 
 

--- a/source/metal/device.d
+++ b/source/metal/device.d
@@ -720,6 +720,16 @@ public:
     MTLLibrary newLibrary(NSString source, MTLCompileOptions options, ref NSError error) @selector("newLibraryWithSource:options:error:");
 
     /**
+      Creates a Metal library instance that contains the functions in the Metal library file at a URL.
+      */
+    MTLLibrary newLibrary(NSURL url, ref NSError error) @selector("newLibraryWithURL:error:");
+
+    /** 
+      Synchronously creates a compute pipeline state and reflection with a function instance.
+     */
+    MTLComputePipelineState newComputePipelineStateWithFunction(MTLFunction computeFunction, MTLPipelineOption options, MTLAutoreleasedComputePipelineReflection reflection, NSError error) @selector("newComputePipelineStateWithFunction:options:reflection:error:"); 
+
+    /**
         Synchronously creates a render pipeline state.
     */
     MTLRenderPipelineState newRenderPipelineState(MTLRenderPipelineDescriptor descriptor, ref NSError error) @selector("newRenderPipelineStateWithDescriptor:error:");


### PR DESCRIPTION
Hello, I am Asadbek. I wanted to add support for Metal GPU backend in ldc compiler and want to use `metal-d` bindings in `dcompute` but it lacks compute related shader bindings. I wanted to contribute them to `metal-d`.

Please, let me know if you need any adjustments to match the project's style guides!