### PR TITLE
Add computeCommandEncoder to MTLCommandBuffer

### DIFF
--- a/source/metal/commandbuffer.d
+++ b/source/metal/commandbuffer.d
@@ -266,5 +266,10 @@ public:
         Marks the end of a debug group and, if applicable, restores the previous group from a stack.
     */
     void popDebugGroup() @selector("popDebugGroup");
+
+    /**
+        Creates a compute command encoder that uses default settings.
+    */
+    MTLComputeCommandEncoder computeCommandEncoder() @selector("computeCommandEncoder");
 }
 


### PR DESCRIPTION
Hello,

This small PR adds `computeCommandEncoder` binding to `MTLCommandBuffer`.